### PR TITLE
mrib.c: use __constant_cpu_to_be32

### DIFF
--- a/src/mrib.c
+++ b/src/mrib.c
@@ -54,7 +54,7 @@ struct mrib_iface {
 	struct uloop_timeout timer;
 };
 
-static uint32_t ipv4_rtr_alert = cpu_to_be32(0x94040000);
+static uint32_t ipv4_rtr_alert = __constant_cpu_to_be32(0x94040000);
 static struct {
 	struct ip6_hbh hdr;
 	struct ip6_opt_router rt;


### PR DESCRIPTION
gcc 7.3.0 thinks that `cpu_to_be32()` is not a compile-time constant, so it does not allow it to initialize `ipv4_rtr_alert` outside of a function.  Se we need to use `__constant_cpu_to_be32` instead.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>