### PR TITLE
example.sh: remove useless mc_forwarding lines

### DIFF
--- a/examples/example.sh
+++ b/examples/example.sh
@@ -34,9 +34,7 @@ for i in `seq 0 4`; do
 	sudo ip netns add "${NS}${i}" || stop 2 "Could not create namespace $NS$i"
 	(
 	sudo ip netns exec $NS$i sysctl -w net.ipv6.conf.all.forwarding=1 && 
-	sudo ip netns exec $NS$i sysctl -w net.ipv6.conf.all.mc_forwarding=1 && 
 	sudo ip netns exec $NS$i sysctl -w net.ipv4.conf.all.forwarding=1 && 
-	sudo ip netns exec $NS$i sysctl -w net.ipv4.conf.all.mc_forwarding=1 && 
 	sudo ip netns exec $NS$i sysctl -w net.ipv4.ip_forward=1 && 
 	sudo ip netns exec $NS$i sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=0
 	) > /dev/null 2>&1 || stop 2 "Could not configure namespace $NS$i"


### PR DESCRIPTION
As far as I know, mc_forwarding is not a writable variable : 

```
nexedi@red:~/multicast$ ls -ln /proc/sys/net/ipv6/conf/all/mc_forwarding
-r--r--r-- 1 0 0 0 Jan 27 11:10 /proc/sys/net/ipv6/conf/all/mc_forwarding

nexedi@red:~/multicast$ ls -ln /proc/sys/net/ipv4/conf/all/mc_forwarding
-r--r--r-- 1 0 0 0 Jan 27 11:10 /proc/sys/net/ipv4/conf/all/mc_forwarding
```

If it is not writable then its presence in the example is confusing.

To set this sysctl variable to True one needs to [activate kernel's mroute code](https://github.com/Oryon/pimbd/blob/master/src/mrib.c#L595).

But maybe it does not always have been the case.